### PR TITLE
fix: Applies RFC 5336 and 4343 for emails that do not have specific rules

### DIFF
--- a/apple_rule.go
+++ b/apple_rule.go
@@ -7,7 +7,8 @@ type AppleRule struct {
 }
 
 func (rule *AppleRule) ProcessUsername(username string) string {
-	return strings.Replace(username, "+", "", -1)
+	result := strings.ToLower(username)
+	return strings.Replace(result, "+", "", -1)
 }
 
 func (rule *AppleRule) ProcessDomain(domain string) string {

--- a/fastmail_rule.go
+++ b/fastmail_rule.go
@@ -7,7 +7,8 @@ type FastmailRule struct {
 }
 
 func (rule *FastmailRule) ProcessUsername(username string) string {
-	return strings.Replace(username, "+", "", -1)
+	result := strings.ToLower(username)
+	return strings.Replace(result, "+", "", -1)
 }
 
 func (rule *FastmailRule) ProcessDomain(domain string) string {

--- a/google_rule.go
+++ b/google_rule.go
@@ -7,7 +7,8 @@ type GoogleRule struct {
 }
 
 func (rule *GoogleRule) ProcessUsername(username string) string {
-	result := strings.Replace(username, ".", "", -1)
+	result := strings.ToLower(username)
+	result = strings.Replace(result, ".", "", -1)
 
 	plusSignIndex := strings.Index(result, "+")
 	if plusSignIndex != -1 {

--- a/microsoft_rule.go
+++ b/microsoft_rule.go
@@ -7,7 +7,8 @@ type MicrosoftRule struct {
 }
 
 func (rule *MicrosoftRule) ProcessUsername(username string) string {
-	return strings.Replace(username, "+", "", -1)
+	result := strings.ToLower(username)
+	return strings.Replace(result, "+", "", -1)
 }
 
 func (rule *MicrosoftRule) ProcessDomain(domain string) string {

--- a/normalizer.go
+++ b/normalizer.go
@@ -47,20 +47,18 @@ func (n *Normalizer) AddRule(domain string, strategy NormalizingRule) {
 func (n *Normalizer) Normalize(email string) string {
 	prepared := strings.TrimSpace(email)
 	prepared = strings.TrimRight(prepared, ".")
-	prepared = strings.ToLower(prepared)
 
 	parts := strings.Split(prepared, "@")
-
 	if len(parts) != 2 {
 		return prepared
 	}
 
-	username := parts[0]
-	domain := parts[1]
+	username := parts[0] // The first part of the address may be case sensitive (RFC 5336)
+	domain := strings.ToLower(parts[1]) // Domain names are case-insensitive (RFC 4343)
 
 	if rule, ok := n.rules[domain]; ok {
 		return rule.ProcessUsername(username) + "@" + rule.ProcessDomain(domain)
 	}
 
-	return prepared
+	return username+ "@" +domain
 }

--- a/normalizer_test.go
+++ b/normalizer_test.go
@@ -22,12 +22,12 @@ func TestNormalizer_NormalizeLower(t *testing.T) {
 
 func TestNormalizer_InvalidEmail(t *testing.T) {
 	normalizer := NewNormalizer()
-	assert.Equal(t, "emailgmail.com", normalizer.Normalize("emAilgmail.cOm."))
+	assert.Equal(t, "emAilgmail.cOm", normalizer.Normalize("emAilgmail.cOm."))
 }
 
 func TestNormalizer_UnknownStrategy(t *testing.T) {
 	normalizer := NewNormalizer()
-	assert.Equal(t, "email@test.com", normalizer.Normalize(" emAil@tEsT.cOm. "))
+	assert.Equal(t, "emAil@test.com", normalizer.Normalize(" emAil@tEsT.cOm. "))
 }
 
 type fakeRule struct {

--- a/protonmail_rule.go
+++ b/protonmail_rule.go
@@ -7,7 +7,8 @@ type ProtonmailRule struct {
 }
 
 func (rule *ProtonmailRule) ProcessUsername(username string) string {
-	return strings.Replace(username, "+", "", -1)
+	result := strings.ToLower(username)
+	return strings.Replace(result, "+", "", -1)
 }
 
 func (rule *ProtonmailRule) ProcessDomain(domain string) string {

--- a/rackspace_rule.go
+++ b/rackspace_rule.go
@@ -7,7 +7,8 @@ type RackspaceRule struct {
 }
 
 func (rule *RackspaceRule) ProcessUsername(username string) string {
-	return strings.Replace(username, "+", "", -1)
+	result := strings.ToLower(username)
+	return strings.Replace(result, "+", "", -1)
 }
 
 func (rule *RackspaceRule) ProcessDomain(domain string) string {

--- a/rambler_rule.go
+++ b/rambler_rule.go
@@ -7,7 +7,8 @@ type RamblerRule struct {
 }
 
 func (rule *RamblerRule) ProcessUsername(username string) string {
-	return strings.Replace(username, "+", "", -1)
+	result := strings.ToLower(username)
+	return strings.Replace(result, "+", "", -1)
 }
 
 func (rule *RamblerRule) ProcessDomain(domain string) string {

--- a/yahoo_rule.go
+++ b/yahoo_rule.go
@@ -7,7 +7,8 @@ type YahooRule struct {
 }
 
 func (rule *YahooRule) ProcessUsername(username string) string {
-	result := strings.Replace(username, ".", "", -1)
+	result := strings.ToLower(username)
+	result = strings.Replace(result, ".", "", -1)
 	return strings.Replace(result, "-", "", -1)
 }
 

--- a/yandex_rule.go
+++ b/yandex_rule.go
@@ -7,7 +7,8 @@ type YandexRule struct {
 }
 
 func (rule *YandexRule) ProcessUsername(username string) string {
-	return strings.Replace(username, "+", "", -1)
+	result := strings.ToLower(username)
+	return strings.Replace(result, "+", "", -1)
 }
 
 func (rule *YandexRule) ProcessDomain(domain string) string {

--- a/zoho_rule.go
+++ b/zoho_rule.go
@@ -7,7 +7,8 @@ type ZohoRule struct {
 }
 
 func (rule *ZohoRule) ProcessUsername(username string) string {
-	return strings.Replace(username, "+", "", -1)
+	result := strings.ToLower(username)
+	return strings.Replace(result, "+", "", -1)
 }
 
 func (rule *ZohoRule) ProcessDomain(domain string) string {


### PR DESCRIPTION
Some mail providers are case sensitive. So the default rule cannot be lowercase.