### PR TITLE
Fix rules for protonmail & add alternative domain names

### DIFF
--- a/domains.go
+++ b/domains.go
@@ -200,3 +200,10 @@ var yandexDomains = []string{
 	"yandex.asia",
 	"yandex.mobi",
 }
+
+var protonmailDomains = []string{
+	"protonmail.ch",
+	"protonmail.com",
+	"proton.me",
+	"pm.me",
+}

--- a/normalizer.go
+++ b/normalizer.go
@@ -43,10 +43,14 @@ func NewNormalizer() *Normalizer {
 		rules[domain] = yandexRule
 	}
 
+	protonmailRule := &ProtonmailRule{}
+	for _, domain := range protonmailDomains {
+		rules[domain] = protonmailRule
+	}
+
 	appleRule := &AppleRule{}
 	rules["icloud.com"] = appleRule
 	rules["me.com"] = appleRule
-	rules["protonmail.ch"] = &ProtonmailRule{}
 	rules["emailsrvr.com"] = &RackspaceRule{}
 	rules["zoho.com"] = &ZohoRule{}
 	return &Normalizer{rules: rules}

--- a/protonmail_rule.go
+++ b/protonmail_rule.go
@@ -8,7 +8,14 @@ type ProtonmailRule struct {
 
 func (rule *ProtonmailRule) ProcessUsername(username string) string {
 	result := strings.ToLower(username)
-	return strings.Replace(result, "+", "", -1)
+	result = strings.Replace(result, ".", "", -1)
+
+	plusSignIndex := strings.Index(result, "+")
+	if plusSignIndex != -1 {
+		result = result[0:plusSignIndex]
+	}
+
+	return result
 }
 
 func (rule *ProtonmailRule) ProcessDomain(domain string) string {

--- a/protonmail_rule_test.go
+++ b/protonmail_rule_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestProtonmailUsername(t *testing.T) {
 	rule := ProtonmailRule{}
-	assert.Equal(t, "t.est", rule.ProcessUsername("t+.est"))
+	assert.Equal(t, "t", rule.ProcessUsername("t+.est"))
 }
 
 func TestProtonmailDomain(t *testing.T) {


### PR DESCRIPTION
Protonmail allows email aliases by adding a plus sign and adding arbitrary text behind it. (see https://proton.me/support/addresses-and-aliases#plus)
However, the current implementation simply replaces the plus sign from the username with an empty string without disposing of text following the plus sign. The proposed change fixes this use case.

Furthermore, there are multiple known domain names used by protonmail (see https://proton.me/support/addresses-and-aliases) but only "protonmail.ch" is handled in the current implementation. The proposed change adds the protonmail normalization rule to the following known alternative domains:
* protonmail.ch
* protonmail.com
* proton.me
* pm.me