### PR TITLE
update go.mod and docs to v3 so imports do not fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to prevent multiple signups. `go-email-normalizer` contains some popular provide
 ## Download
 
 ```shell
-go get -u github.com/dimuska139/go-email-normalizer/v2
+go get -u github.com/dimuska139/go-email-normalizer/v3
 ```
 
 ## Usage
@@ -23,7 +23,7 @@ package main
 import (
 	"fmt"
 	"strings"
-	normalizer "github.com/dimuska139/go-email-normalizer/v2"
+	normalizer "github.com/dimuska139/go-email-normalizer/v3"
 )
 
 type customRule struct {}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dimuska139/go-email-normalizer/v2
+module github.com/dimuska139/go-email-normalizer/v3
 
 go 1.14
 


### PR DESCRIPTION
I noticed my upgrade to v3 failed with invalid version: go.mod has non-.../v3 module path "github.com/dimuska139/go-email-normalizer/v2".  I assume this will sort it out. Thanks!